### PR TITLE
Remove leading space from function name.

### DIFF
--- a/includes/server/class-EDD_RI.php
+++ b/includes/server/class-EDD_RI.php
@@ -262,7 +262,7 @@ class EDD_RI {
 		if ( $price > 0 ) {
 
 			$args[ 'key' ] = urldecode( $data[ 'license' ] );
-			$edd_sl        = function_exists( ' edd_software_licensing' ) ? edd_software_licensing() : false;
+			$edd_sl        = function_exists( 'edd_software_licensing' ) ? edd_software_licensing() : false;
 
 			if ( false === $edd_sl ) {
 				die( 'error' );


### PR DESCRIPTION
The leading space in the function name breaks the `function_exists()` check.